### PR TITLE
Adding a link to Gnosis Zodiac UI guide to setup SafeSnap.

### DIFF
--- a/plugins/safesnap.md
+++ b/plugins/safesnap.md
@@ -10,9 +10,10 @@ With help of SafeSnap and Gnosis Safe, you can have a trustless on-chain executi
 
 ## Setup
 
-Here is the official guide on how to setup a SafeSnap for your project:
+Here are the official guides on how to setup a SafeSnap for your project:
 
-{% embed url="https://github.com/gnosis/dao-module/blob/main/docs/setup\_guide.md" %}
+Gnosis UI setup: {% embed url="https://gnosis.github.io/zodiac/docs/tutorial-module-reality/get-started" %}
+Manual setup: {% embed url="https://github.com/gnosis/dao-module/blob/main/docs/setup\_guide.md" %}
 
 Learn more about SafeSnap in this video:
 


### PR DESCRIPTION
Adding a link to Gnosis Zodiac UI guide to setup SafeSnap.

[Zodiac UI + template generator](https://gnosis.github.io/zodiac/docs/tutorial-module-reality/get-started)
<img width="1413" alt="Capture d’écran 2021-11-07 à 12 23 49" src="https://user-images.githubusercontent.com/55286013/140633508-6309a72b-aa7f-4ec7-bf5b-43fb7d9ed8ca.png">

[Manual setup](https://github.com/gnosis/dao-module/blob/main/docs/setup\_guide.md)
<img width="1413" alt="Capture d’écran 2021-11-07 à 12 24 04" src="https://user-images.githubusercontent.com/55286013/140633503-a7775004-47e5-42c0-ab76-d7484e6d4d62.png">
