### PR TITLE
fix: update hub testnet URL

### DIFF
--- a/tools/api/README.md
+++ b/tools/api/README.md
@@ -33,7 +33,7 @@ https://hub.snapshot.org/graphql
 Demo hub
 
 ```
-https://testnet.snapshot.org/graphql
+https://testnet.hub.snapshot.org/graphql
 ```
 
 ## Queries

--- a/tools/snapshot.js.md
+++ b/tools/snapshot.js.md
@@ -57,7 +57,7 @@ yarn build
 ```javascript
 import snapshot from '@snapshot-labs/snapshot.js';
 
-const hub = 'https://hub.snapshot.org'; // or https://testnet.snapshot.org for testnet
+const hub = 'https://hub.snapshot.org'; // or https://testnet.hub.snapshot.org for testnet
 const client = new snapshot.Client712(hub);
 ```
 


### PR DESCRIPTION
Change to new URL, More details: https://discord.com/channels/955773041898573854/1030772407226601522/1175036485842509884


Todo:
- [x] Merge after snapshot.js