### PR TITLE
fix: typos in documentation files

### DIFF
--- a/space-handbook/delegation.md
+++ b/space-handbook/delegation.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Which Voting Strategy to choose to enable enable users to vote on behalf of
+  Which Voting Strategy to choose to enable users to vote on behalf of
   their delegators?
 ---
 

--- a/spaces/add-avatar.md
+++ b/spaces/add-avatar.md
@@ -22,7 +22,7 @@ To get a logo for your space, images you need to do a pull request on this repos
 You will need to create a folder with the id of your space \(example: "my-space.eth"\). In this folder you need a file "space.png" and "logo.png" \(for the first strategy\) and "logo1.png" if you have a second strategy.
 
 {% hint style="danger" %}
-All the images must be squared and less than 50kb.
+All the images must be square and less than 50kb.
 {% endhint %}
 
 {% hint style="info" %}

--- a/strategies.md
+++ b/strategies.md
@@ -57,7 +57,7 @@ Strategies are defined in the space `index.json` file level. This is how to add 
 }
 ```
 
-Strategies can be used to create a score from on-chain data, the data does not necessary need to be monetary, we can imagine a strategy that calculate how many POAP you own or use any other data available on-chain to issue a score.
+Strategies can be used to create a score from on-chain data, the data does not necessarily need to be monetary, we can imagine a strategy that calculates how many POAP you own or use any other data available on-chain to issue a score.
 
 ## More strategies are on Snapshot.js here:
 

--- a/user-guides/delegation.md
+++ b/user-guides/delegation.md
@@ -103,7 +103,7 @@ Snapshot uses the Gnosis "Delegate Registry" contract here:\
 [https://github.com/gnosis/delegate-registry](https://github.com/gnosis/delegate-registry)
 
 The contract is deployed on this address: [0x469788fE6E9E9681C6ebF3bF78e7Fd26Fc015446](https://etherscan.io/address/0x469788fE6E9E9681C6ebF3bF78e7Fd26Fc015446#code)\
-The contract is also available on Optimism, Arbitrum, Polygon, Base, BNB Chain, Gnoisis Chain, Fantom and Sepolia at the same address.
+The contract is also available on Optimism, Arbitrum, Polygon, Base, BNB Chain, Gnosis Chain, Fantom and Sepolia at the same address.
 
 Delegations are stored on this subgraph:\
 [https://thegraph.com/explorer/subgraph/snapshot-labs/snapshot](https://thegraph.com/explorer/subgraph/snapshot-labs/snapshot)

--- a/user-guides/plugins/galxe.md
+++ b/user-guides/plugins/galxe.md
@@ -6,7 +6,7 @@ description: Learn what Galxe plugin is and how to add it to your space.
 
 [Galxe](https://galxe.com/) is building a protocol that powers on-chain credentials with plug-and-play NFT modules. The permissionless infrastructure allows everyone to create, distribute, and gamify NFTs with customized on-chain data.
 
-With the Galxy plugin users can easily create a campaign and integrate it into [Snapshot.](https://snapshot.org) This solution will incentivize communities to participate in the proposal vote by rewarding them with OATs (On-Chain Achievement Tokens). After users have voted, they can claim an OAT directly from the Project Galaxy Plugin section on the proposal page on Snapshot.
+With the Galxe plugin users can easily create a campaign and integrate it into [Snapshot.](https://snapshot.org) This solution will incentivize communities to participate in the proposal vote by rewarding them with OATs (On-Chain Achievement Tokens). After users have voted, they can claim an OAT directly from the Project Galaxy Plugin section on the proposal page on Snapshot.
 
 ## Setup
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "enable enable users" to "enable users"
Corrected "Gnoisis Chain" to "Gnosis Chain".
Corrected "Galxy" to "Galxe".
Corrected "squared" to "square" and much more.


Please review the changes and let me know if any additional changes are needed.