### PR TITLE
chore: update the using-safe-multi-sig guide for clarity

### DIFF
--- a/user-guides/using-safe-multi-sig.md
+++ b/user-guides/using-safe-multi-sig.md
@@ -10,29 +10,42 @@ You can use a Gnosis Safe to vote, create a proposal or setup a space on Snapsho
 Your Safe has to be on the same network as the Space is. Head to Space settings, **Strategies** tab to check the Space's network.
 {% endhint %}
 
-### Gnosis Safe interface
-
 {% hint style="info" %}
-**Spaces can be created and updated** only by Ethereum Mainnet accounts.\
+**Spaces can be created and updated** only by Ethereum Mainnet accounts.
 
-
-Voting and proposals related actions are supported by Ethereum Mainnet, Optimism Mainnet, Arbitrum Mainnet, Polygon Mainnet, BSC and Goerli Testnet.
+Voting and proposals are accepted from Space's network only.
 {% endhint %}
 
-To use your multi-sig wallet to interact with Snapshot you can login to Snapshot from Gnosis Safe UI by adding [https://snapshot.org](https://snapshot.org) as a Safe app. When you try an action like vote, it will create a pending transaction in your Safe transactions queue. This transaction must be confirmed by the Safe signers within **72 hours.** Once the transaction is confirmed the vote will be sent and will appear on the proposal.
+## Connecting your Safe
 
-{% hint style="info" %}
-By default, the confirmation modal has to stay open until all Safe signers confirm. \
-\
-If you prefer to close the modal, you need to enable on chain signatures. Follow the steps from [#asynchronous-signing](using-safe-multi-sig.md#asynchronous-signing "mention") to change your Safe settings.
-{% endhint %}
+To connect your Safe to Snapshot
 
-{% embed url="https://www.loom.com/share/31e22ddf57b84fbc9882d9d87b4dded4" %}
+1. Go to your Safe wallet like `https://app.safe.global/apps/open?safe=<NETWORK>:<SAFE_ADDRESS>`
+2. Go to the **Apps** tab.
+3. Search for Snapshot and click on it.
+4. You should now see the Snapshot interface connected to your Safe wallet.
+
+{% embed url="https://www.loom.com/share/f02b6ec7a95e44a88f9a4ebba281e002" %}
+
+## Signing with your Safe
+
+There are two ways to sign with your Safe multi-sig wallet on Snapshot:
+
+1. **Synchronous signing (offchain)** - you keep the confirmation modal open until all Safe signers confirm the transaction.
+
+2. **Asynchronous signing (onchain)** - you can close the confirmation modal and the transaction will be created in your Safe transactions queue. The Safe signers can confirm it later.
+
+For more information, refer to the [Gnosis Safe documentation](https://help.safe.global/en/articles/40783-what-are-signed-messages).
+
+### Synchronous signing
+
+By default, the first signer who is signing a message will have to keep the confirmation modal open until all other signers confirm the message.
+
+This happens offchain and does not create a transaction in your Safe transactions queue. but in messages tab of your Safe. Other signers need to confirm the message in their Safe interface.
 
 ### Asynchronous signing
 
 If you'd like to enable asynchronous signing for all Safe's signers and not have to keep the modal open, you have to enable on-chain signatures in the Safe settings.\
-
 
 1. Go to Safe Settings -> Safe Apps.
 2. Enable `Always use on-chain signatures`
@@ -41,3 +54,4 @@ If you'd like to enable asynchronous signing for all Safe's signers and not have
 
 That's all :tada: Signers can now sign even if you you close the confirmation modal.
 
+It will create a pending transaction in your Safe transactions queue. This transaction must be confirmed by the Safe signers within **144 hours.**


### PR DESCRIPTION
### Summary
- improved the explanation of connecting your Safe to Snapshot 🔗
- clarified the signing process with synchronous and asynchronous options ✍️
- updated transaction confirmation time from 72 to 144 hours ⏳